### PR TITLE
feat: add pipeline and use env var for the cookie

### DIFF
--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -1,0 +1,70 @@
+# use Ubuntu 22.04 & Node 18
+
+# Seems like the documentation can not be deployed for multiple branch, but only on pushes to main.
+# See 5 on https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site
+
+name: Scrape and deploy data to GitHub Pages
+
+env:
+  SESSION_ID: ${{ secrets.SESSION_ID }} # get the SESSION_ID from GitHub Secrets of the repository
+
+on:
+  workflow_dispatch:
+#  push:
+#    branches:
+#      - master
+
+jobs:
+  run-scrapers: # run the python scripts to scrape and format the data
+    name: Scrape data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run getCourseNumbers.py
+        run: python3 getCourseNumbers.py
+      - name: Run scraper.py
+        run: python3 scraper.py
+      - name: Run analyser.py
+        run: python3 analyzer.py extension
+      - name: Copy data
+        run: |
+          mkdir data
+          cp -r extension/db.html data/
+          cp -r data.json data/
+      # Fix permissions of the documentation folder (actions/upload-pages-artifact requirement)
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "./data/" | while read line; do
+           echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      - name: Save data to upload to GitLab Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: data/
+  deploy: # publish the data to the GitHub Pages
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [run-scrapers]
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -54,12 +54,30 @@ Data was gathered using a Python script that scraped DTU's coursebase and format
  1. Install python dependencies `pip3 install -r requirements.txt`
 
 ## Gather data
- 1. Create a file called `secret.txt` containing the `ASP.NET_SessionId` cookie set when you are logged into https://kurser.dtu.dk with a DTU account. Make sure there is no leading or trailing whitespace and newlines.
-If you are using Firefox, you can get the cookie by pressing F12, going to the storage tab, and copying the value of the `ASP.NET_SessionId` cookie.
- 2. Update the list of courses using `python3 getCourseNumbers.py`
- 3. Run the scraper `python3 scraper.py`
- 4. Analyze the data using `python3 analyzer.py extension`
- 
+
+### Locally
+
+1. Create an env var called `SESSION_ID` containing the `ASP.NET_SessionId` cookie set when you are logged
+   into https://kurser.dtu.dk with a DTU account. Make sure there is no leading or trailing whitespace and newlines.
+   If you are using Firefox, you can get the cookie by pressing F12, going to the storage tab, and copying the value of
+   the `ASP.NET_SessionId` cookie.
+2. Update the list of courses using `python3 getCourseNumbers.py`
+3. Run the scraper `python3 scraper.py`
+4. Analyze the data using `python3 analyzer.py extension`
+
+### Using GitHub Workflow (will also push to GitHub Pages)
+
+1. In _Settings > Secrets and variables > Actions_ create/edit a _Repository secret_ called `SESSION_ID` containing the
+   `ASP.NET_SessionId` cookie set when you are logged into https://kurser.dtu.dk with a DTU account. Make sure there is
+   no leading or trailing whitespace and newlines.
+   If you are using Firefox, you can get the cookie by pressing F12, going to the storage tab, and copying the value of
+   the `ASP.NET_SessionId` cookie.
+2. Go to https://github.com/SMKIDRaadet/dtu-course-analyzer/actions/workflows/update-data.yaml, select _Run workflow_
+   then the branch and then _Run workflow_.
+
+This will publish two pages [db.html](https://smkidraadet.github.io/dtu-course-analyzer/)
+and [data.json](https://seb-sti1.github.io/dtu-course-analyzer/data.json) to GitHub Pages.
+
 ## Debugging
 ### Chrome
  1. Open the extensions page

--- a/analyzer.py
+++ b/analyzer.py
@@ -1,3 +1,8 @@
+"""
+This file analyse the data from coursedic.json and create the result in the data.json, [extension]/db.html
+and [extension]/db/data.js.
+"""
+
 import json
 import sys
 import pprint

--- a/getCourseNumbers.py
+++ b/getCourseNumbers.py
@@ -1,14 +1,35 @@
+"""
+This file is used to create coursenumbers.txt, which is used in scraper.py.
+It connects to kurser.dtu.dk/search using the key from the env var SESSION_ID.
+"""
 import requests
 from bs4 import BeautifulSoup
+import os
+
+
+def key_error(exists=False):
+    BOLD = '\033[1m'
+    WARNING = '\033[93m'
+    ENDC = '\033[0m'
+
+    if not exists:
+        print(BOLD, WARNING, "No SESSION_ID found in environment variables.", ENDC)
+    else:
+        print(BOLD, WARNING, "The provided SESSION_ID seems incorrect.", ENDC)
+
+    print(BOLD, WARNING,
+          "Add a Github Secrets (see https://docs.github.com/en/actions/security-guides/using-secrets-in-github"
+          "-actions#creating-secrets-for-a-repository) named SESSION_ID containing the value of the ASP.NET_SessionId"
+          " cookie from kurser.dtu.dk", ENDC)
+    exit(-1)
 
 
 # this url is the url of the search page with all the filters applied
 url = "https://kurser.dtu.dk/search?CourseCode=&SearchKeyword=&SchedulePlacement=E1%3BE2%3BE3%3BE4%3BE5%3BE1A%3BE2A%3BE3A%3BE4A%3BE5A%3BE1B%3BE2B%3BE3B%3BE4B%3BE5B%3BE7%3BE&SchedulePlacement=E1%3BE1A%3BE1B&SchedulePlacement=E1A&SchedulePlacement=E1B&SchedulePlacement=E2%3BE2A%3BE2B&SchedulePlacement=E2A&SchedulePlacement=E2B&SchedulePlacement=E3%3BE3A%3BE3B&SchedulePlacement=E3A&SchedulePlacement=E3B&SchedulePlacement=E4%3BE4A%3BE4B&SchedulePlacement=E4A&SchedulePlacement=E4B&SchedulePlacement=E5%3BE5A%3BE5B&SchedulePlacement=E5A&SchedulePlacement=E5B&SchedulePlacement=E7&SchedulePlacement=F1%3BF2%3BF3%3BF4%3BF5%3BF1A%3BF2A%3BF3A%3BF4A%3BF5A%3BF1B%3BF2B%3BF3B%3BF4B%3BF5B%3BF7%3BF&SchedulePlacement=F1%3BF1A%3BF1B&SchedulePlacement=F1A&SchedulePlacement=F1B&SchedulePlacement=F2%3BF2A%3BF2B&SchedulePlacement=F2A&SchedulePlacement=F2B&SchedulePlacement=F3%3BF3A%3BF3B&SchedulePlacement=F3A&SchedulePlacement=F3B&SchedulePlacement=F4%3BF4A%3BF4B&SchedulePlacement=F4A&SchedulePlacement=F4B&SchedulePlacement=F5%3BF5A%3BF5B&SchedulePlacement=F5A&SchedulePlacement=F5B&SchedulePlacement=F7&SchedulePlacement=January&SchedulePlacement=August%3BJuly%3BJune&SchedulePlacement=August&SchedulePlacement=July&SchedulePlacement=June&CourseType=&TeachingLanguage="
 
-# Get the key from secret.txt
-file = open("secret.txt", 'r')
-key=file.read()
-file.close()
+key = os.environ.get('SESSION_ID', False)
+if not key:
+    key_error()
 
 # send a request to the url with the key
 r = requests.get(url, cookies={'ASP.NET_SessionId' : key})
@@ -17,6 +38,9 @@ data = soup.find_all("img" , {"class" : "basketIcon clickable"})
 
 # get the course numbers from the HTML data
 courseNumbers = [i['data-coursecode'] for i in data]
+
+if len(courseNumbers) == 0:
+    key_error(True)
 
 # Write to file
 open('coursenumbers.txt', 'w').write(','.join(courseNumbers))

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,8 @@
+ """
+This script scrapes the DTU course evaluation and grade data from the DTU website and stores it in coursedic.json.
+It uses the course numbers from coursenumbers.txt (from getCourseNumbers.py) and the key from the env var SESSION_ID
+to access the data.
+"""
 import time
 start_time = time.time()
 
@@ -9,6 +14,7 @@ import json
 import datetime
 import traceback
 from tqdm import tqdm
+import os
 
 now = datetime.datetime.now()
 
@@ -18,9 +24,17 @@ file = open("coursenumbers.txt", 'r')
 courses = file.read().split(",")
 file.close()
 
-file = open("secret.txt", 'r')
-key = file.read()
-file.close()
+key = os.environ.get('SESSION_ID', False)
+if not key:
+    BOLD = '\033[1m'
+    WARNING = '\033[93m'
+    ENDC = '\033[0m'
+
+    print(BOLD, WARNING, "No SESSION_ID found in environment variables.")
+    print("Add a Github Secrets (see https://docs.github.com/en/actions/security-guides/using-secrets-in-github"
+          "-actions#creating-secrets-for-a-repository) named SESSION_ID containing the value of the ASP.NET_SessionId"
+          " cookie from kurser.dtu.dk", ENDC)
+    exit(-1)
 
 
 def printlog(txt):


### PR DESCRIPTION
As requested in https://github.com/SMKIDRaadet/dtu-course-analyzer/issues/30#issuecomment-2569292120 this is the first PR regarding the creation of the pipeline to run and publish the data scrape by the python scripts.


---
If it's okay, i will wait for this to be reviewed and merged before doing the next PRs (The refactor to use data on Github pages, The manifest V3 changes, (The changes to the Readme that doesn't depend on the refactor))